### PR TITLE
Fix variable definition in name.h

### DIFF
--- a/name.c
+++ b/name.c
@@ -2,6 +2,8 @@
 #include "builtin.h"
 #include "name.h"
 
+Name names;
+
 I equalsStr(Str l, Str r) { return 0==strcmp(l,r); }
 SET_HASH_TABLE(Str, V, hash_string, equalsStr, FREE, ddel, ((V){0,0}));
 

--- a/name.h
+++ b/name.h
@@ -5,4 +5,4 @@ SET_HASH_TABLE_H(Str, V);
 
 typedef StrV_HashMap Name;
 
-Name names;
+extern Name names;


### PR DESCRIPTION
According to C standard each global variable should only be defined in a single translation unit. gcc only started enforcing that recently, and my gcc 13.1.1 complained about multiple definition of `names`.

The solution that's supposed to be the good practice according to my quick search is to declare the variable in the header file as `extern`, and define it in the source file. With this fix I was able to compile and run the interpreter.